### PR TITLE
Revert "chore: Remove calculated hash for original zh file in docs"

### DIFF
--- a/.github/workflows/reverse-sync.yml
+++ b/.github/workflows/reverse-sync.yml
@@ -2,6 +2,8 @@ name: Reverse Sync
 
 env:
   TARGET_REPO: alaudadevops/tektoncd-operator
+  IGNORE_PATHS: .github/,README.md
+  SYNCED_PATHS: docs/ theme/ .yarn/ doom.config.yml yarn.lock tsconfig.json package.json sites.yaml
 
 on:
   pull_request:
@@ -9,9 +11,6 @@ on:
     branches:
       - main
       - release-*
-    paths:
-      - '*'
-      - '!README.md'
 
 
 jobs:
@@ -77,13 +76,17 @@ jobs:
         echo "base_commit=$base_commit" >> $GITHUB_OUTPUT
 
         # Get list of changed files in the PR
-        git diff --name-only $base_commit $merge_commit > ../changed_files.txt
+        ignore_pattern=$(echo "$IGNORE_PATHS" | sed 's/,/|/g' | sed 's|/$||g')
+        echo "🙈 Ignored paths: $ignore_pattern"
+
+        git diff --name-only $base_commit $merge_commit | grep -v -E "^($ignore_pattern)" > ../changed_files.txt
 
         echo "📋 Changed files in PR:"
         cat ../changed_files.txt
 
+        IFS=',' read -ra PATHS <<< "$SYNCED_PATHS"
         # Check if any documentation files were changed
-        if grep -E "(^docs/|^README\.md$)" ../changed_files.txt; then
+        if [ -s ../changed_files.txt ]; then
           echo "has_doc_changes=true" >> $GITHUB_OUTPUT
           echo "✅ Documentation changes detected"
         else
@@ -117,7 +120,9 @@ jobs:
         base_commit="${{ steps.get_changes.outputs.base_commit }}"
 
         # Create a patch with only the documentation changes
-        git format-patch $base_commit..$merge_commit --stdout -- docs/ README.md > ../changes.patch
+        ignore_pattern=$(echo "$IGNORE_PATHS" | sed 's/,/|/g' | sed 's|/$||g')
+        echo "📑 Will only sync these paths: $SYNCED_PATHS"
+        git format-patch $base_commit..$merge_commit --stdout -- $SYNCED_PATHS > ../changes.patch
 
         cd ../target-docs
 
@@ -129,12 +134,10 @@ jobs:
 
             # Fallback: manual copy of changed files
             while IFS= read -r file; do
-              if [[ "$file" == docs/* ]] || [[ "$file" == "README.md" ]]; then
-                if [ -f "../devops-pipelines-docs/$file" ]; then
-                  mkdir -p "$(dirname "$file")"
-                  cp "../devops-pipelines-docs/$file" "$file"
-                  echo "✅ Copied: $file"
-                fi
+              if [ -f "../devops-pipelines-docs/$file" ]; then
+                mkdir -p "$(dirname "$file")"
+                cp "../devops-pipelines-docs/$file" "$file"
+                echo "✅ Copied: $file"
               fi
             done < ../changed_files.txt
           }
@@ -143,12 +146,10 @@ jobs:
 
           # Manual copy approach
           while IFS= read -r file; do
-            if [[ "$file" == docs/* ]] || [[ "$file" == "README.md" ]]; then
-              if [ -f "../devops-pipelines-docs/$file" ]; then
-                mkdir -p "$(dirname "$file")"
-                cp "../devops-pipelines-docs/$file" "$file"
-                echo "✅ Copied: $file"
-              fi
+            if [ -f "../devops-pipelines-docs/$file" ]; then
+              mkdir -p "$(dirname "$file")"
+              cp "../devops-pipelines-docs/$file" "$file"
+              echo "✅ Copied: $file"
             fi
           done < ../changed_files.txt
         fi

--- a/docs/en/apis/advanced_apis/results/index.mdx
+++ b/docs/en/apis/advanced_apis/results/index.mdx
@@ -3,6 +3,7 @@ weight: 20
 i18n:
   title:
     en: Results
+sourceSHA: 309f1a9373dac81cd438b1b4b9eea0fdcc06aec0b3d35614336d2c0e67b877cd
 title: Results
 ---
 

--- a/docs/en/apis/advanced_apis/results/intro.md
+++ b/docs/en/apis/advanced_apis/results/intro.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to API Usage
 weight: 30
+sourceSHA: 87fe4929856a049f4a3d5b47a831d80bab84aeb9fe95d0e19ea17beb45e979c1
 ---
 
 # Introduction to API Usage

--- a/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results.mdx
+++ b/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 100
+sourceSHA: a598b5a8669b9cdb2e2506db8b45ca5e86695d21379b9b4fe38dc1b761dbc3a8
 ---
 
 # Results List

--- a/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results_uuid.mdx
+++ b/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results_uuid.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 200
+sourceSHA: b9d2eaf608563763f21317b409eb1f4a876fb92fe1339a223cd5788ecb681a49
 ---
 
 # Results Details

--- a/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results_uuid_logs.mdx
+++ b/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results_uuid_logs.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 400
+sourceSHA: ee8963e55cef330bd194bf9494040e9577b6cba601438da14947fc007822eb67
 ---
 
 # Result logs List

--- a/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results_uuid_records.mdx
+++ b/docs/en/apis/advanced_apis/results/results_v1alpha2_parents_results_uuid_records.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 300
+sourceSHA: da1c16d39fd92f75e46aaa6298dd383507ab0f1931f81a700a6140c12e918afc
 ---
 
 # Result records List

--- a/docs/en/apis/index.mdx
+++ b/docs/en/apis/index.mdx
@@ -3,6 +3,7 @@ weight: 900
 i18n:
   title:
     en: API Reference
+sourceSHA: c830eb7d28f21bd7eee185b5ad4d4d101e063a8fa1dab01815d5f2b8d33fc35f
 title: API Reference
 ---
 

--- a/docs/en/apis/intro.mdx
+++ b/docs/en/apis/intro.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 10
+sourceSHA: 4e36b8b0000885c9764d32a18d6e52e1ccd26781a242711e70d3aad203ecad18
 ---
 
 # Introduction

--- a/docs/en/apis/kubernetes_apis/index.mdx
+++ b/docs/en/apis/kubernetes_apis/index.mdx
@@ -1,4 +1,5 @@
 ---
+sourceSHA: 92f748f3892a616e69d1c7ec8f3eae4b2befbea40527458501e4e5a56e16a52e
 title: Kubernetes APIs
 weight: 20
 ---

--- a/docs/en/apis/kubernetes_apis/operator/openshiftpipelinesascodes.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/openshiftpipelinesascodes.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 180
+sourceSHA: de5d8c3bec08fee92dc0d94a25f493ae21300a005b8ce31ea0d68a0633fc9301
 ---
 
 # OpenShift Pipelines as Code \[operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektonchains.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektonchains.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 140
+sourceSHA: 31284947bd4b422b2ad1ca1b0c72b1052ff093a3e10dcb44f7f46571bf249c87
 ---
 
 # TektonChain [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektonconfig.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektonconfig.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 110
+sourceSHA: 334045b882c578b582dddddfcb7a62a471291377c515c64182483d0915498ef8
 ---
 
 # TektonConfig [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektonhubs.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektonhubs.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 150
+sourceSHA: c60d262285f7038edbcc1da26b9ebcfaaf3ae19c16c4646b95d36b796b5c6dcc
 ---
 
 # TektonHub [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektoninstallerset.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektoninstallerset.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 110
+sourceSHA: fcfe8425a7d54aec659b18d5944e94993269c4657c682412334216232f679475
 ---
 
 # TektonInstallerSet [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektoninstallersets.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektoninstallersets.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 170
+sourceSHA: 086067de6da10b33d52917c92df0b358eb7749638555cb34435b2cb8fe601a18
 ---
 
 # TektonInstallerSet [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektonpipelines.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektonpipelines.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 120
+sourceSHA: d64da8ecb8f3bd3a12df10b491af1dfca0c0190f0dea0f8e3bfd9296e5a0f742
 ---
 
 # TektonPipeline [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektonresults.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektonresults.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 160
+sourceSHA: 5ba913e5ea306392d1815b7c6b244f466c87171c0a63feb25ff36c8ff42e7636
 ---
 
 # TektonResult [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/operator/tektontriggers.mdx
+++ b/docs/en/apis/kubernetes_apis/operator/tektontriggers.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 130
+sourceSHA: d43739dfcdf60af7b7725ad2689c0a3c99edc001e00afd7477d7725e3e5bfb28
 ---
 
 # TektonTrigger [operator.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/triggers/clusterinterceptor.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/clusterinterceptor.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 110
+sourceSHA: cb56559a5db99722832c6fe2418b634f07a96ebf9e0210182b3a5fd7ee1afe6a
 ---
 
 # ClusterInterceptor [triggers.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/triggers/clustertriggerbinding.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/clustertriggerbinding.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 100
+sourceSHA: 79af4e90fab165687ef79a25c332295c8ee10a8eb20971c15320cec10bd00d30
 ---
 
 # ClusterTriggerBinding [triggers.tekton.dev/v1beta1]

--- a/docs/en/apis/kubernetes_apis/triggers/eventlistener.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/eventlistener.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 30
+sourceSHA: fef4fe40c508978d994e33a72a894cbc55a51ddeea8d8edbf8c101a918eccca4
 ---
 
 # EventListener [triggers.tekton.dev/v1beta1]

--- a/docs/en/apis/kubernetes_apis/triggers/index.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/index.mdx
@@ -3,6 +3,7 @@ weight: 30
 i18n:
   title:
     en: Triggers
+sourceSHA: 92f748f3892a616e69d1c7ec8f3eae4b2befbea40527458501e4e5a56e16a52e
 title: Triggers
 ---
 

--- a/docs/en/apis/kubernetes_apis/triggers/interceptor.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/interceptor.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 70
+sourceSHA: 33f190e458d23fcfeea927fa32926bba930cfb83b325da0a6cd5865b8bd1e617
 ---
 
 # Interceptor [triggers.tekton.dev/v1alpha1]

--- a/docs/en/apis/kubernetes_apis/triggers/triggerbinding.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/triggerbinding.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 50
+sourceSHA: 7b3d0b6748995cdc2a0e41352f7852b6893842022e96c2b06cb7abe28eb2a08b
 ---
 
 # TriggerBinding [triggers.tekton.dev/v1beta1]

--- a/docs/en/apis/kubernetes_apis/triggers/triggers.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/triggers.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 10
+sourceSHA: 1927d435627bf7b5f05fecb3818e1ceece9b4cb3fb45d21ce813ae7417de2c68
 ---
 
 # Trigger [triggers.tekton.dev/v1beta1]

--- a/docs/en/apis/kubernetes_apis/triggers/triggertemplate.mdx
+++ b/docs/en/apis/kubernetes_apis/triggers/triggertemplate.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 20
+sourceSHA: fa279ee082cca28eb719f1d89f6a0dc9417fb220fbd62519f6dac9af4911deba
 ---
 
 # TriggerTemplate [triggers.tekton.dev/v1beta1]

--- a/docs/en/configure/customize_options.mdx
+++ b/docs/en/configure/customize_options.mdx
@@ -1,6 +1,7 @@
 ---
 title: Adjusting Optional Configuration Items of Subcomponents
 weight: 10
+sourceSHA: e8dc68e13b6a5eae97587db9ce12a604d239694ca4fe0d9d821af5791c22db01
 ---
 
 # Adjusting Optional Configuration Items of Subcomponents

--- a/docs/en/configure/customize_tekton_pipeline.mdx
+++ b/docs/en/configure/customize_tekton_pipeline.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuring Resource Quotas for Pipeline Components
 weight: 20
+sourceSHA: 244ed8262157e281525632c51199cb09fbcb12cbc4beda33d3a21740c497329c
 ---
 
 # Configuring Resource Quotas for Pipeline Components

--- a/docs/en/configure/pruner_resources.mdx
+++ b/docs/en/configure/pruner_resources.mdx
@@ -1,6 +1,7 @@
 ---
 title: Regular Cleanup of TaskRun and PipelineRun Resources
 weight: 50
+sourceSHA: 313ba737795bfb999dc2a2966d96c050aeb829bb8ec33ec574de730a4082f125
 ---
 
 # Regular Cleanup of TaskRun and PipelineRun Resources

--- a/docs/en/development/component-quickstart/index.md
+++ b/docs/en/development/component-quickstart/index.md
@@ -1,5 +1,6 @@
 ---
 created: '2025-01-07'
+sourceSHA: 1f19cac3ea0607ba2d121d6734b84d2150fab490db2b9e53af98021051a20f97
 ---
 
 # Component Quick Start
@@ -235,7 +236,7 @@ metadata:
         #   - https://pipelinesascode.com/docs/guide/matchingevents/#matching-a-pipelinerun-to-specific-path-changes
         #   - https://en.wikipedia.org/wiki/Glob_%28programming%29
         #   - https://pipelinesascode.com/docs/guide/cli/#test-globbing-pattern
-        # TL;DR:
+        # TL;DR: 
         #   - `.tekton` matches all file changes in the `.tekton` directory.
         #   - `.tekton/**` matches all file changes within the `.tekton` directory.
         #   - `.tekton/.*` does not match all file changes within the `.tekton` directory.
@@ -331,7 +332,7 @@ spec:
         echo "update_image_version.sh values.yaml ${IMAGE}"
         update_image_version.sh values.yaml ${IMAGE}
 
-        # **Important** Update the component's version number
+        # **Important** Update the component's version number 
         # It will be based on the calculated last changed commit sha, used as the version suffix.
 
         # Get the current version and remove the -.* suffix

--- a/docs/en/development/index.mdx
+++ b/docs/en/development/index.mdx
@@ -1,6 +1,7 @@
 ---
 created: '2025-01-07'
 weight: 1000
+sourceSHA: 75c34d0d72e02898d2113ea25e4d650c5813026359d0fbe191f5f0a4003ea1d0
 ---
 
 # Development

--- a/docs/en/development/update-frontend/index.md
+++ b/docs/en/development/update-frontend/index.md
@@ -1,5 +1,6 @@
 ---
 created: '2025-01-10'
+sourceSHA: 423aae74086ccd5e58bf95963dba1872dde2b1e215377c15812fd75e0246284b
 ---
 
 # Update Frontend Images

--- a/docs/en/how_to/deploy_global.mdx
+++ b/docs/en/how_to/deploy_global.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deploying tekton-pipelines in a global cluster through TektonConfig
 weight: 12
+sourceSHA: 287827cef494ef625663ba58b166f501370529a167b85b165f8716055bb7a512
 ---
 
 # Deploying tekton-pipelines in a global cluster through TektonConfig

--- a/docs/en/how_to/index.mdx
+++ b/docs/en/how_to/index.mdx
@@ -3,6 +3,7 @@ weight: 400
 i18n:
   title:
     en: How To
+sourceSHA: d837f194b6c9f8058518d18eb2bc43fbf785f18020d6237122f502585f653538
 title: How To
 ---
 

--- a/docs/en/hub/architecture.mdx
+++ b/docs/en/hub/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 20
+sourceSHA: 508a17e48c8a204f0dd687d8a3619719bf5e75b2514145e72e1b0d5f72faf021
 ---
 
 # Architecture

--- a/docs/en/hub/index.mdx
+++ b/docs/en/hub/index.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 650
+sourceSHA: c7c51f67d66813d5092b61a9b655e83480cf3a5a6278c11a9d958bb41b4a1c51
 ---
 
 # Hub

--- a/docs/en/index.mdx
+++ b/docs/en/index.mdx
@@ -1,4 +1,5 @@
 ---
+sourceSHA: 98fa82cb94165bc3a005c9bc616756185acea329bf9d9a47317557939b1c5e39
 weight: 10
 ---
 

--- a/docs/en/overview/features.mdx
+++ b/docs/en/overview/features.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 20
+sourceSHA: fd953fbcfccf537583abc76490cce5d4a69e3e8985c33f0f7788e0d7f22a3600
 i18n:
   additionalPrompts: Do not translate project names and keep them as is like Tekton Pipelines, Tekton Triggers, Tekton Chains, Tekton Hub, Pipeline-as-Code, Tekton Results
 ---

--- a/docs/en/overview/index.mdx
+++ b/docs/en/overview/index.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 100
+sourceSHA: bc41c3854a0b20a2af73129062603452edf9a9bcb8314eced8b5b24b368a4d1d
 ---
 
 # Overview

--- a/docs/en/overview/intro.mdx
+++ b/docs/en/overview/intro.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 10
+sourceSHA: 0a2d43dba1d3bda12069a5a85bdc2d0d713f9cb6596d59acd67ffdd5c9c4f370
 i18n:
   additionalPrompts: Do not translate project names and keep them as is like Tekton Pipelines, Tekton Triggers, Tekton Chains, Tekton Hub, Pipeline-as-Code, Tekton Results
 ---

--- a/docs/en/results/architecture.mdx
+++ b/docs/en/results/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 20
+sourceSHA: 40155ea232f165caffcdc31f86a0887747f31547bafc5855f32831053776695d
 ---
 
 # Architecture

--- a/docs/en/results/concepts/index.mdx
+++ b/docs/en/results/concepts/index.mdx
@@ -3,6 +3,7 @@ weight: 30
 i18n:
   title:
     en: Concepts
+sourceSHA: 2c830418701b8c2c7fd4d286f21bf5b6eb68a6f08b4ba54c68373538971c7763
 title: Concepts
 ---
 

--- a/docs/en/results/index.mdx
+++ b/docs/en/results/index.mdx
@@ -1,4 +1,5 @@
 ---
+sourceSHA: 46be47e03110959e9129c7cdb7de80da53d1352df16265a02368330b1c12aadc
 weight: 750
 ---
 

--- a/docs/en/results/intro.mdx
+++ b/docs/en/results/intro.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 10
+sourceSHA: 75b523d852e1a209ae80b1420bd336ad2e782d4cac31e3cb060f9ebd627d958c
 ---
 
 # Introduction

--- a/docs/en/results/permissions.mdx
+++ b/docs/en/results/permissions.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 80
+sourceSHA: 80a7ecd66cd9ce5252ddc1a40ce65ee072b136b380fa43cd5b062ff6face24ae
 ---
 
 <K8sPermissionTable functions={['devopsv4-tekton-results', 'devopsv4-tekton-results-admin', 'devopsv4-tekton-cluster-admin']} />

--- a/docs/en/results/quick_start.mdx
+++ b/docs/en/results/quick_start.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 40
+sourceSHA: 2440c61387f788dd976c0fcdd63a64ce3ad449663a2b8144d2645c5ef4e6459c
 ---
 
 # Quick Start

--- a/docs/en/triggers/architecture.mdx
+++ b/docs/en/triggers/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 20
+sourceSHA: 5bd5013186a875741b3642a1a9bf6273a6b3bd6db4d27e61dbd5ffc8134d327a
 ---
 
 # Architecture

--- a/docs/en/triggers/index.mdx
+++ b/docs/en/triggers/index.mdx
@@ -1,4 +1,5 @@
 ---
+sourceSHA: 98fa82cb94165bc3a005c9bc616756185acea329bf9d9a47317557939b1c5e39
 weight: 600
 ---
 

--- a/docs/en/triggers/intro.mdx
+++ b/docs/en/triggers/intro.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 10
+sourceSHA: d1959fed1405788b0ceb5104bcdd909132c1ab285dc6683862a424bc59d49a81
 ---
 
 # Introduction

--- a/docs/en/triggers/quick_start.mdx
+++ b/docs/en/triggers/quick_start.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 40
+sourceSHA: bf8f76fc1e85dcb50e08e768990ac4a072a49790ba6fc95bc4e20e322b5b6e78
 ---
 
 # Quick Start

--- a/docs/en/triggers/trouble_shooting/index.mdx
+++ b/docs/en/triggers/trouble_shooting/index.mdx
@@ -3,6 +3,7 @@ weight: 70
 i18n:
   title:
     en: Troubleshooting
+sourceSHA: 8f04f4df58848dd0c8fded6b7971a0c1a25b7ae586810b24fad45cf7798c8fa2
 title: Troubleshooting
 ---
 

--- a/docs/en/triggers/trouble_shooting/pipeline_not_triggered.mdx
+++ b/docs/en/triggers/trouble_shooting/pipeline_not_triggered.mdx
@@ -1,5 +1,6 @@
 ---
 weight: 10
+sourceSHA: 4894d6ee9f6876a61b243b991087cc3b3083a7c424fdf0374d5300a347099774
 ---
 
 
@@ -18,16 +19,16 @@ There are several possible causes for this issue:
 3. The `ServiceAccount` used by the `EventListener` deployment does not have enough permissions.
 4. The `Trigger` is not configured correctly.
 
-## Problem Investigation
+## Problem Investigation 
 
-Given the possible issues mentioned above, follow the steps to find the root cause of the problem:
+Given the possible issues mentioned above, follow the steps to find the root cause of the problem: 
 
-### Webhook configuration was not setup correctly
+### Webhook configuration was not setup correctly 
 
   1. Access your repository/settings using an account with appropriate permissions.
   2. Check all webhook settings and confirm with the platform administrator details regarding the target address of the webhook.
   3. Make sure the required events are enabled by the webhook. For Gitlab events please refer to [GitLab Event Triggers](../how_to/gitlab_events.mdx)
-
+  
 
 ### EventLister not deployed or setup incorrectly
 


### PR DESCRIPTION
Reverts alauda/devops-pipelines-docs#1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new metadata field to the front matter of all English documentation files for improved traceability.
  * Made minor formatting adjustments in two documentation files (comment spacing and blank lines).
  * No changes to the visible content or instructions within the documentation.

* **Chores**
  * Updated GitHub Actions workflow to generalize and simplify file synchronization and change detection logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->